### PR TITLE
Verse extension

### DIFF
--- a/client/src/components/Forms/BibleVerse.vue
+++ b/client/src/components/Forms/BibleVerse.vue
@@ -64,6 +64,7 @@ export default {
     props: [ "value" ],
     created: function() {
         this.location = this.value;
+        this.incoming_value = this.value;
     },
     computed: {
         ContributionTypes(){

--- a/client/src/components/List/Elements/Contribution/Desk.vue
+++ b/client/src/components/List/Elements/Contribution/Desk.vue
@@ -97,6 +97,7 @@ export default {
         async pushElement(){
             var computedElement = this.element;
             computedElement.publishedDate = Date.now();
+            computedElement.isLive = true;
             await this.sendDeskToFeedRef(computedElement)
         },
         async updateElement(){

--- a/client/src/components/List/Elements/Contribution/Desk.vue
+++ b/client/src/components/List/Elements/Contribution/Desk.vue
@@ -1,4 +1,4 @@
-<template>
+  <template>
     <li class="mb-2" v-click-outside="() => editMode = false" @click.stop="editMode = true">
         <div class=" list-item bg-background-2">
             <template v-if="!editMode">
@@ -50,7 +50,6 @@
 
 <script>
 import { mapActions } from 'vuex'
-
 import { ContributionTypes, ContributionTypesLabels } from '@/models/contribution.js'
 import DateHelper from '@/mixins/date.js'
 import ClickOutside from 'vue-click-outside'
@@ -80,9 +79,7 @@ export default {
             if (this.editableElement.type == ContributionTypes.BIBLEVERSE && this.editableElement.author == "") {
                 return false;
             }
-
             return this.editableElement.content && this.editableElement.content.length > 0;
-
         },
         isNotCompleted(){
             return !this.isCompleted
@@ -97,7 +94,6 @@ export default {
         async pushElement(){
             var computedElement = this.element;
             computedElement.publishedDate = Date.now();
-            computedElement.isLive = true;
             await this.sendDeskToFeedRef(computedElement)
         },
         async updateElement(){

--- a/client/src/components/List/Elements/Contribution/LiveDesk.vue
+++ b/client/src/components/List/Elements/Contribution/LiveDesk.vue
@@ -20,18 +20,18 @@
                     <BibleVerse v-model="editableElement" />
                 </template>
 
-                <button class="btn bg-bluewood mr-1" :class="{'disabled': isNotCompleted}" @click.stop="showRemoveConfirm1 = true">+1</button>
-                <button class="btn bg-bluewood mx-1" :class="{'disabled': isNotCompleted}" @click.stop="showRemoveConfirm2 = true">+2</button>
-                <button class="btn bg-bluewood mx-1" :class="{'disabled': isNotCompleted}" @click.stop="showRemoveConfirm3 = true">+3</button>
-                <button class="btn bg-bluewood mx-1" :class="{'disabled': isNotCompleted}" @click.stop="showRemoveConfirm4 = true">+4</button>
+                <button class="btn bg-bluewood mr-1" :class="{'disabled': isNotCompleted}" @click.stop="showExtendConfirm1 = true">+1</button>
+                <button class="btn bg-bluewood mx-1" :class="{'disabled': isNotCompleted}" @click.stop="showExtendConfirm2 = true">+2</button>
+                <button class="btn bg-bluewood mx-1" :class="{'disabled': isNotCompleted}" @click.stop="showExtendConfirm3 = true">+3</button>
+                <button class="btn bg-bluewood mx-1" :class="{'disabled': isNotCompleted}" @click.stop="showExtendConfirm4 = true">+4</button>
 
                 <button class="btn bg-bluewood ml-1" :class="{'disabled': isNotCompleted}" @click="updateElement">{{$t('actions.save')}}</button>
             </section>
         </div>
-        <Confirm v-if="showRemoveConfirm1" @cancel="showRemoveConfirm1 = false" @confirm="extendVerse(1)" :message="$t('dialogs.confirm-extend-verse-1')" />
-        <Confirm v-if="showRemoveConfirm2" @cancel="showRemoveConfirm2 = false" @confirm="extendVerse(2)" :message="$t('dialogs.confirm-extend-verse-2')" />
-        <Confirm v-if="showRemoveConfirm3" @cancel="showRemoveConfirm3 = false" @confirm="extendVerse(3)" :message="$t('dialogs.confirm-extend-verse-3')" />
-        <Confirm v-if="showRemoveConfirm4" @cancel="showRemoveConfirm4 = false" @confirm="extendVerse(4)" :message="$t('dialogs.confirm-extend-verse-4')" />
+        <Confirm v-if="mediabank-webhook-passwordshowExtendConfirm1" @cancel="showExtendConfirm1 = false" @confirm="extendVerse(1)" :message="$t('dialogs.confirm-extend-verse-1')" />
+        <Confirm v-if="showExtendConfirm2" @cancel="showExtendConfirm2 = false" @confirm="extendVerse(2)" :message="$t('dialogs.confirm-extend-verse-2')" />
+        <Confirm v-if="showExtendConfirm3" @cancel="showExtendConfirm3 = false" @confirm="extendVerse(3)" :message="$t('dialogs.confirm-extend-verse-3')" />
+        <Confirm v-if="showExtendConfirm4" @cancel="showExtendConfirm4 = false" @confirm="extendVerse(4)" :message="$t('dialogs.confirm-extend-verse-4')" />
     </li>
 </template>
 
@@ -55,10 +55,10 @@ export default {
         return {
             editMode: false,
             editableElement: this.element,
-            showRemoveConfirm1: false,
-            showRemoveConfirm2: false,
-            showRemoveConfirm3: false,
-            showRemoveConfirm4: false,
+            showExtendConfirm1: false,
+            showExtendConfirm2: false,
+            showExtendConfirm3: false,
+            showExtendConfirm4: false,
         }
     },
     computed: {
@@ -105,10 +105,10 @@ export default {
             this.editableElement.publishedDate = Date.now();
             await this.updateLiveVerse(this.editableElement);
             this.editMode = false
-            this.showRemoveConfirm1 = false
-            this.showRemoveConfirm2 = false
-            this.showRemoveConfirm3 = false
-            this.showRemoveConfirm4 = false
+            this.showExtendConfirm1 = false
+            this.showExtendConfirm2 = false
+            this.showExtendConfirm3 = false
+            this.showExtendConfirm4 = false
         },
 
         getProperty(property){

--- a/client/src/components/List/Elements/Contribution/LiveDesk.vue
+++ b/client/src/components/List/Elements/Contribution/LiveDesk.vue
@@ -28,7 +28,7 @@
                 <button class="btn bg-bluewood ml-1" :class="{'disabled': isNotCompleted}" @click="updateElement">{{$t('actions.save')}}</button>
             </section>
         </div>
-        <Confirm v-if="mediabank-webhook-passwordshowExtendConfirm1" @cancel="showExtendConfirm1 = false" @confirm="extendVerse(1)" :message="$t('dialogs.confirm-extend-verse-1')" />
+        <Confirm v-if="showExtendConfirm1" @cancel="showExtendConfirm1 = false" @confirm="extendVerse(1)" :message="$t('dialogs.confirm-extend-verse-1')" />
         <Confirm v-if="showExtendConfirm2" @cancel="showExtendConfirm2 = false" @confirm="extendVerse(2)" :message="$t('dialogs.confirm-extend-verse-2')" />
         <Confirm v-if="showExtendConfirm3" @cancel="showExtendConfirm3 = false" @confirm="extendVerse(3)" :message="$t('dialogs.confirm-extend-verse-3')" />
         <Confirm v-if="showExtendConfirm4" @cancel="showExtendConfirm4 = false" @confirm="extendVerse(4)" :message="$t('dialogs.confirm-extend-verse-4')" />

--- a/client/src/components/List/Elements/Contribution/LiveDesk.vue
+++ b/client/src/components/List/Elements/Contribution/LiveDesk.vue
@@ -1,0 +1,98 @@
+<template>
+    <li class="mb-2" v-click-outside="() => editMode = false" @click.stop="editMode = true">
+        <div class=" list-item bg-downy">
+            <template v-if="!editMode">
+                <template>
+                    <section class="w-full">
+                        <p class="elType">{{ContributionTypesLabels[element.type]}}</p>
+                        <p class="text-white text-base w-full">{{element.content}}</p>
+                        <div class="text-gray-400 text-sm mb-2">{{element.author}}</div>
+                        <div class="text-gray-400 text-sm mb-2">{{date(element.date)}}</div>
+                    </section>
+                    <section class="overlay h-full">
+                        <button class="h-10 mt-3 btn bg-bluewood" @click="withdrawElement">{{$t('queue.withdraw')}}</button>
+                    </section>
+                </template>
+            </template>
+            <section v-else class="w-full flex flex-wrap justify-end">
+                <template>
+                    <p class="elType">{{ContributionTypesLabels[element.type]}}</p>
+                    <BibleVerse v-model="editableElement" />
+                </template>
+                <button class="btn bg-bluewood" :class="{'disabled': isNotCompleted}" @click="updateElement">{{$t('actions.save')}}</button>
+            </section>
+        </div>
+    </li>
+</template>
+
+<script>
+import { mapActions } from 'vuex'
+
+import { ContributionTypes, ContributionTypesLabels } from '@/models/contribution.js'
+import DateHelper from '@/mixins/date.js'
+import ClickOutside from 'vue-click-outside'
+import BibleVerse from '@/components/Forms/BibleVerse.vue'
+export default {
+    components: { BibleVerse },
+    props: {
+        element: {
+            type: Object,
+            required: true
+        },
+    },
+    data: function(){
+        return {
+            editMode: false,
+            editableElement: this.element,
+        }
+    },
+    computed: {
+        ContributionTypes(){
+            return ContributionTypes;
+        },
+        ContributionTypesLabels(){
+            return ContributionTypesLabels;
+        },
+        isCompleted(){
+            if (this.editableElement.type == ContributionTypes.BIBLEVERSE && this.editableElement.author == "") {
+                return false;
+            }
+
+            return this.editableElement.content && this.editableElement.content.length > 0;
+
+        },
+        isNotCompleted(){
+            return !this.isCompleted
+        }
+    },
+    mixins: [DateHelper],
+    methods: {
+        ...mapActions('contributions', ['updateLiveVerse', 'withdrawLiveVerse']),
+
+        async withdrawElement(){
+            await this.withdrawLiveVerse(this.element);
+        },
+        async updateElement(){
+            if (this.isCompleted) {
+                console.log(this.editableElement.id)
+                await this.updateLiveVerse(this.editableElement);
+                this.editMode = false
+            }
+        },
+        getProperty(property){
+            return (property == null) ? null : property;
+        }
+    },
+    directives: {
+        ClickOutside
+    }
+}
+</script>
+<style scoped>
+.elType {
+   color: rgba(156, 163, 175);
+   font-style: italic;
+   font-size: 13px;
+   text-align: right;
+}
+</style>

--- a/client/src/components/List/Elements/Contribution/LiveDesk.vue
+++ b/client/src/components/List/Elements/Contribution/LiveDesk.vue
@@ -19,7 +19,7 @@
                     <p class="text-grey-100 elType">{{ContributionTypesLabels[element.type]}}</p>
                     <BibleVerse v-model="editableElement" />
                 </template>
-                
+
                 <button class="btn bg-bluewood mr-1" :class="{'disabled': isNotCompleted}" @click.stop="showRemoveConfirm1 = true">+1</button>
                 <button class="btn bg-bluewood mx-1" :class="{'disabled': isNotCompleted}" @click.stop="showRemoveConfirm2 = true">+2</button>
                 <button class="btn bg-bluewood mx-1" :class="{'disabled': isNotCompleted}" @click.stop="showRemoveConfirm3 = true">+3</button>
@@ -44,7 +44,7 @@ import ClickOutside from 'vue-click-outside'
 import BibleVerse from '@/components/Forms/BibleVerse.vue'
 import Confirm from '@/components/Dialogs/Confirm.vue'
 export default {
-    components: { BibleVerse, Confirm }, 
+    components: { BibleVerse, Confirm },
     props: {
         element: {
             type: Object,
@@ -84,7 +84,7 @@ export default {
     mixins: [DateHelper],
     methods: {
         ...mapActions('contributions', ['updateLiveVerse', 'withdrawLiveVerse']),
-        
+
         async withdrawElement(){
             await this.withdrawLiveVerse(this.element);
         },

--- a/client/src/components/List/Elements/Contribution/LiveDesk.vue
+++ b/client/src/components/List/Elements/Contribution/LiveDesk.vue
@@ -75,6 +75,7 @@ export default {
         },
         async updateElement(){
             if (this.isCompleted) {
+                this.editableElement.publishedDate = Date.now();
                 await this.updateLiveVerse(this.editableElement);
                 this.editMode = false
             }

--- a/client/src/components/List/Elements/Contribution/LiveDesk.vue
+++ b/client/src/components/List/Elements/Contribution/LiveDesk.vue
@@ -4,10 +4,10 @@
             <template v-if="!editMode">
                 <template>
                     <section class="w-full">
-                        <p class="elType">{{ContributionTypesLabels[element.type]}}</p>
-                        <p class="text-white text-base w-full">{{element.content}}</p>
-                        <div class="text-gray-400 text-sm mb-2">{{element.author}}</div>
-                        <div class="text-gray-400 text-sm mb-2">{{date(element.date)}}</div>
+                        <p class="text-grey-100 elType">{{ContributionTypesLabels[element.type]}}</p>
+                        <p class="text-white font-medium text-base w-full">{{element.content}}</p>
+                        <div class="text-grey-100 text-sm mb-2">{{element.author}}</div>
+                        <div class="text-grey-100 text-sm mb-2">{{date(element.date)}}</div>
                     </section>
                     <section class="overlay h-full">
                         <button class="h-10 mt-3 btn bg-bluewood" @click="withdrawElement">{{$t('queue.withdraw')}}</button>
@@ -16,7 +16,7 @@
             </template>
             <section v-else class="w-full flex flex-wrap justify-end">
                 <template>
-                    <p class="elType">{{ContributionTypesLabels[element.type]}}</p>
+                    <p class="text-grey-100 elType">{{ContributionTypesLabels[element.type]}}</p>
                     <BibleVerse v-model="editableElement" />
                 </template>
                 <button class="btn bg-bluewood" :class="{'disabled': isNotCompleted}" @click="updateElement">{{$t('actions.save')}}</button>
@@ -67,14 +67,14 @@ export default {
     },
     mixins: [DateHelper],
     methods: {
-        ...mapActions('contributions', ['updateLiveVerse', 'withdrawLiveVerse']),
+        ...mapActions('contributions', ['updateLiveVerse', 'withdrawLiveVerse', 'removeWasLive']),
 
         async withdrawElement(){
+            await this.removeWasLive(this.element.id)
             await this.withdrawLiveVerse(this.element);
         },
         async updateElement(){
             if (this.isCompleted) {
-                console.log(this.editableElement.id)
                 await this.updateLiveVerse(this.editableElement);
                 this.editMode = false
             }
@@ -90,7 +90,6 @@ export default {
 </script>
 <style scoped>
 .elType {
-   color: rgba(156, 163, 175);
    font-style: italic;
    font-size: 13px;
    text-align: right;

--- a/client/src/components/LiveScreens/TV/ScreenF/VerseDisplay.vue
+++ b/client/src/components/LiveScreens/TV/ScreenF/VerseDisplay.vue
@@ -61,7 +61,7 @@ export default {
         }
     },
     methods: {
-        ...mapActions('contributions', ['bindFeedRef']),
+        ...mapActions('contributions', ['bindFeedRef', 'addWasLive']),
         loadLastVerse() {
             if ((!this.loaded && !this.displayPrevious) || this.latestFeed.length == 0) {
                 this.verseToDisplay = null;
@@ -75,11 +75,12 @@ export default {
             }
 
             const lastElement = this.latestFeed[0]
+            console.log(lastElement)
             if (!lastElement || lastElement.type != ContributionTypes.BIBLEVERSE) {
                 this.verseToDisplay = null;
                 return
             }
-
+            this.addWasLive(lastElement.id)
             this.verseToDisplay = lastElement;
         }
     },
@@ -96,7 +97,7 @@ export default {
         verseToDisplay() {
             // Hide after x seconds
             if (this.verseToDisplay != null) {
-                setTimeout(() => {this.verseToDisplay = null }, this.displayTime * 1000);
+                setTimeout(() => {this.verseToDisplay = null}, this.displayTime * 1000)
             }
         },
     }

--- a/client/src/components/LiveScreens/TV/ScreenF/VerseDisplay.vue
+++ b/client/src/components/LiveScreens/TV/ScreenF/VerseDisplay.vue
@@ -30,7 +30,6 @@
 import { mapGetters, mapActions } from 'vuex';
 import FeedEntry from '@/components/Feed/Base.vue'
 import { ContributionTypes } from '@/models/contribution.js'
-
 export default {
     components: {
         FeedEntry
@@ -40,6 +39,7 @@ export default {
         return {
             loaded: false,
             verseToDisplay: null,
+            oldLatestFeed: [],
         }
     },
     computed: {
@@ -61,26 +61,22 @@ export default {
         }
     },
     methods: {
-        ...mapActions('contributions', ['bindFeedRef', 'addWasLive']),
+        ...mapActions('contributions', ['bindFeedRef']),
         loadLastVerse() {
             if ((!this.loaded && !this.displayPrevious) || this.latestFeed.length == 0) {
                 this.verseToDisplay = null;
                 return
             }
-
             if (this.displayPrevious) {
                 let verses = this.latestFeed.filter((el, i) => (el.type == ContributionTypes.BIBLEVERSE))
                 this.verseToDisplay = verses[0] || null;
                 return
             }
-
             const lastElement = this.latestFeed[0]
-            console.log(lastElement)
             if (!lastElement || lastElement.type != ContributionTypes.BIBLEVERSE) {
                 this.verseToDisplay = null;
                 return
             }
-            this.addWasLive(lastElement.id)
             this.verseToDisplay = lastElement;
         }
     },
@@ -92,12 +88,15 @@ export default {
             this.loadLastVerse();
         },
         latestFeed() {
-            this.loadLastVerse()
+            if(this.latestFeed >= this.oldLatestFeed) {
+                this.loadLastVerse()
+            }
+            this.oldLatestFeed = this.latestFeed
         },
         verseToDisplay() {
             // Hide after x seconds
             if (this.verseToDisplay != null) {
-                setTimeout(() => {this.verseToDisplay = null}, this.displayTime * 1000)
+                setTimeout(() => {this.verseToDisplay = null }, this.displayTime * 1000);
             }
         },
     }
@@ -108,19 +107,15 @@ export default {
     left: 124px;
     top: 866px;
 }
-
 .verse-inner {
     padding: 18px 38px;
 }
-
 .slide-enter-active,
 .slide-leave-active {
     transition: opacity 1.3s, transform 1.3s;
 }
-
 .slide-enter, .slide-leave-to {
     opacity: 0;
     translateX: 10%;
 }
-
 </style>

--- a/client/src/localization/en.json
+++ b/client/src/localization/en.json
@@ -186,7 +186,11 @@
 		"are-you-sure": "Are you sure?",
 		"confirm-action": "Please confirm this action",
 		"confirm-delete-event": "All data related to this event will be deleted. This action is irreversible.",
-		"confirm-delete-contribution": "This contribution will be deleted permanently. This action is irreversible."
+		"confirm-delete-contribution": "This contribution will be deleted permanently. This action is irreversible.",
+		"confirm-extend-verse-1": "The verse will be extended by 1 verses and shown live again",
+		"confirm-extend-verse-2": "The verse will be extended by 2 verses and shown live again",
+		"confirm-extend-verse-3": "The verse will be extended by 3 verses and shown live again",
+		"confirm-extend-verse-4": "The verse will be extended by 4 verses and shown live again"
 	},
 	"profile-pictures": {
 		"thisWeek": "This week",

--- a/client/src/localization/en.json
+++ b/client/src/localization/en.json
@@ -149,6 +149,7 @@
 		"number-elements": "{number} element(s)",
 		"frequency": "Publish frequency (in seconds)",
 		"push": "Push",
+		"withdraw": "Withdraw",
 		"notice": "Notice",
 		"pusher-notice": "Closing this window will stop the autopush.",
 		"auto-push-notice": "Automatic push is activated."

--- a/client/src/store/contributions.js
+++ b/client/src/store/contributions.js
@@ -56,7 +56,7 @@ export default {
         }),
 
         addToDeskRef: firestoreAction((context, entry) => {
-            return context.getters.deskRef.add(entry);
+            return context.getters.deskRef.add(entry).then(function(docRef){docRef.update({id:`${docRef.id}`})});
         }),
         sendDeskToFeedRef: firestoreAction(async (context, entry) => {
             await context.getters.feedRef.doc(entry.id).set({ ...entry })
@@ -79,7 +79,7 @@ export default {
             return context.getters.contributionsRef.doc(entry.id).update({ tags: ['rejected'] })
         }),
         updateDeskElementRef: firestoreAction((context, entry) => {
-            return context.getters.deskRef.doc(entry.id).set({ ...entry });
+            return context.getters.deskRef.doc(entry.id).update({ ...entry });
         }),
         removeDeskElementRef: firestoreAction((context, entryId) => {
             return context.getters.deskRef.doc(entryId).delete();
@@ -97,6 +97,15 @@ export default {
         removeLiveRef: firestoreAction((context, entry) => {
             return context.getters.feedRef.doc(entry.id).delete();
         }),
+
+        addWasLive: firestoreAction((context, id) => {
+            return context.getters.feedRef.doc(id).update({ wasLive: true })
+        }),
+        removeWasLive: firestoreAction((context, id) => {
+            return context.getters.feedRef.doc(id).update({ wasLive: false })
+        }),
+
+
     },
     getters: {
         contributionsRef: (_s, _g, _r, rootGetters) => {

--- a/client/src/store/contributions.js
+++ b/client/src/store/contributions.js
@@ -1,3 +1,4 @@
+
 import { firestoreAction  } from 'vuexfire'
 import { db } from '@/data/db'
 import firebase from 'firebase'
@@ -9,7 +10,6 @@ export default {
         contributions: [],
         queue: [],
         desk: [],
-        testDesk: [],
         liveDesk: [],
         feed: [],
         additionalFeed: [],
@@ -46,40 +46,21 @@ export default {
 
             return context.bindFirestoreRef('feedByEvent', db.collection(`events/${screenEvent.id}/feed-outgoing`));
         }),
-
+                   
         bindDeskRef: firestoreAction(context => {
-            return context.bindFirestoreRef('testDesk', context.getters.deskRef.orderBy('date', 'desc'))
+            return context.bindFirestoreRef('desk', context.getters.deskRef.orderBy('date', 'desc'))
         }),
 
         bindLiveDeskRef: firestoreAction(context => {
-            return context.bindFirestoreRef('liveDesk', context.getters.feedRef.where("type", "==", 3).orderBy('date', 'desc'))
+            return context.bindFirestoreRef('liveDesk', context.getters.feedRef.where("type", "==", 3).orderBy('publishedDate', 'desc'))
         }),
-
-        // bindDeskRef: firestoreAction(context => {
-        //     return context.bindFirestoreRef('desk', context.getters.deskRef.orderBy('date', 'desc'))
-        // }), 
-
-        // bindDeskRef: firestoreAction(context => {
-        //     return context.bindFirestoreRef('desk', test.push(test2))
-        // }),
-
-        // bindDeskRef: firestoreAction(async context => {
-        //     await context.bindFirestoreRef('test', context.getters.feedRef.where("type", "==", 3).orderBy('date', 'desc'))
-        //     await context.bindFirestoreRef('test2', context.getters.deskRef.orderBy('date', 'desc'))
-        //     return context.bindFirestoreRef('desk', this.test.push(this.test2))
-        // }),
-
-        // bindDeskRef: firestoreAction(context => {
-        //     return context.bindFirestoreRef('test', context.getters.feedRef.where("type", "==", 3).orderBy('date', 'desc')).then(context.bindFirestoreRef('test2', context.getters.deskRef.orderBy('date', 'desc'))).then(context.bindFirestoreRef('desk', test.push(test2)))
-        // }),
-
 
         addToDeskRef: firestoreAction((context, entry) => {
             return context.getters.deskRef.add(entry);
         }),
         sendDeskToFeedRef: firestoreAction(async (context, entry) => {
             await context.getters.feedRef.doc(entry.id).set({ ...entry })
-            // return context.getters.deskRef.doc(entry.id).delete()
+            return context.getters.deskRef.doc(entry.id).delete()
         }),
         updateContribsCount: firestoreAction(async (context, count) => {
             const contribCounter = await context.rootGetters['events/selectedEventRef'].collection('counters').doc('feedContributions')
@@ -102,6 +83,13 @@ export default {
         }),
         removeDeskElementRef: firestoreAction((context, entryId) => {
             return context.getters.deskRef.doc(entryId).delete();
+        }),
+        updateLiveVerse: firestoreAction((context, entry) => {
+            return context.getters.feedRef.doc(entry.id).update({ ...entry });
+        }),
+        withdrawLiveVerse: firestoreAction(async (context, entry) => {
+            await context.getters.deskRef.doc(entry.id).set({ ...entry })
+            return context.getters.feedRef.doc(entry.id).delete()
         }),
         removeQueueElementRef: firestoreAction((context, entryId) => {
             return context.getters.queueRef.doc(entryId).delete();
@@ -145,10 +133,6 @@ export default {
         },
         queueByEventIdRef: (state, getters, rootState, rootGetters) => (eventId) => {
             return db.collection('events').doc(eventId).collection('feed-approved')
-        },
-
-        test3: (state, getters) => {
-            return getters.desk.push(test);
         },
     }
 }

--- a/client/src/store/contributions.js
+++ b/client/src/store/contributions.js
@@ -58,11 +58,11 @@ export default {
 
         addToDeskRef: firestoreAction(async (context, entry) => {
             await context.getters.deskRef.add(entry).then(function(docRef){docRef.update({id:`${docRef.id}`})});
-            // return context.getters.deskRef.doc(entry.id).update({ wasLive: false })
+
         }),
         sendDeskToFeedRef: firestoreAction(async (context, entry) => {
             await context.getters.feedRef.doc(entry.id).set({ ...entry })
-            await context.getters.feedRef.doc(entry.id).update({ wasLive: false })
+
             return context.getters.deskRef.doc(entry.id).delete()
         }),
         updateContribsCount: firestoreAction(async (context, count) => {
@@ -92,7 +92,7 @@ export default {
         }),
         withdrawLiveVerse: firestoreAction(async (context, entry) => {
             await context.getters.deskRef.doc(entry.id).set({ ...entry })
-            await context.getters.deskRef.doc(entry.id).update({ wasLive: false })
+
             return context.getters.feedRef.doc(entry.id).delete()
         }),
         removeQueueElementRef: firestoreAction((context, entryId) => {
@@ -101,15 +101,6 @@ export default {
         removeLiveRef: firestoreAction((context, entry) => {
             return context.getters.feedRef.doc(entry.id).delete();
         }),
-
-        addWasLive: firestoreAction((context, id) => {
-            return context.getters.feedRef.doc(id).update({ wasLive: true })
-        }),
-        removeWasLive: firestoreAction((context, id) => {
-            return context.getters.feedRef.doc(id).update({ wasLive: false })
-        }),
-
-
     },
     getters: {
         contributionsRef: (_s, _g, _r, rootGetters) => {

--- a/client/src/store/contributions.js
+++ b/client/src/store/contributions.js
@@ -9,6 +9,8 @@ export default {
         contributions: [],
         queue: [],
         desk: [],
+        testDesk: [],
+        liveDesk: [],
         feed: [],
         additionalFeed: [],
         screenFeed: [],
@@ -44,15 +46,40 @@ export default {
 
             return context.bindFirestoreRef('feedByEvent', db.collection(`events/${screenEvent.id}/feed-outgoing`));
         }),
+
         bindDeskRef: firestoreAction(context => {
-            return context.bindFirestoreRef('desk', context.getters.deskRef.orderBy('date', 'desc'))
+            return context.bindFirestoreRef('testDesk', context.getters.deskRef.orderBy('date', 'desc'))
         }),
+
+        bindLiveDeskRef: firestoreAction(context => {
+            return context.bindFirestoreRef('liveDesk', context.getters.feedRef.where("type", "==", 3).orderBy('date', 'desc'))
+        }),
+
+        // bindDeskRef: firestoreAction(context => {
+        //     return context.bindFirestoreRef('desk', context.getters.deskRef.orderBy('date', 'desc'))
+        // }), 
+
+        // bindDeskRef: firestoreAction(context => {
+        //     return context.bindFirestoreRef('desk', test.push(test2))
+        // }),
+
+        // bindDeskRef: firestoreAction(async context => {
+        //     await context.bindFirestoreRef('test', context.getters.feedRef.where("type", "==", 3).orderBy('date', 'desc'))
+        //     await context.bindFirestoreRef('test2', context.getters.deskRef.orderBy('date', 'desc'))
+        //     return context.bindFirestoreRef('desk', this.test.push(this.test2))
+        // }),
+
+        // bindDeskRef: firestoreAction(context => {
+        //     return context.bindFirestoreRef('test', context.getters.feedRef.where("type", "==", 3).orderBy('date', 'desc')).then(context.bindFirestoreRef('test2', context.getters.deskRef.orderBy('date', 'desc'))).then(context.bindFirestoreRef('desk', test.push(test2)))
+        // }),
+
+
         addToDeskRef: firestoreAction((context, entry) => {
             return context.getters.deskRef.add(entry);
         }),
         sendDeskToFeedRef: firestoreAction(async (context, entry) => {
             await context.getters.feedRef.doc(entry.id).set({ ...entry })
-            return context.getters.deskRef.doc(entry.id).delete()
+            // return context.getters.deskRef.doc(entry.id).delete()
         }),
         updateContribsCount: firestoreAction(async (context, count) => {
             const contribCounter = await context.rootGetters['events/selectedEventRef'].collection('counters').doc('feedContributions')
@@ -118,6 +145,10 @@ export default {
         },
         queueByEventIdRef: (state, getters, rootState, rootGetters) => (eventId) => {
             return db.collection('events').doc(eventId).collection('feed-approved')
+        },
+
+        test3: (state, getters) => {
+            return getters.desk.push(test);
         },
     }
 }

--- a/client/src/store/contributions.js
+++ b/client/src/store/contributions.js
@@ -15,6 +15,7 @@ export default {
         additionalFeed: [],
         screenFeed: [],
         feedByEvent: [],
+        oldLatestFeed: [],
     },
     actions: {
         bindContributionsRef: firestoreAction(context => {
@@ -46,7 +47,7 @@ export default {
 
             return context.bindFirestoreRef('feedByEvent', db.collection(`events/${screenEvent.id}/feed-outgoing`));
         }),
-                   
+
         bindDeskRef: firestoreAction(context => {
             return context.bindFirestoreRef('desk', context.getters.deskRef.orderBy('date', 'desc'))
         }),
@@ -55,11 +56,13 @@ export default {
             return context.bindFirestoreRef('liveDesk', context.getters.feedRef.where("type", "==", 3).orderBy('publishedDate', 'desc'))
         }),
 
-        addToDeskRef: firestoreAction((context, entry) => {
-            return context.getters.deskRef.add(entry).then(function(docRef){docRef.update({id:`${docRef.id}`})});
+        addToDeskRef: firestoreAction(async (context, entry) => {
+            await context.getters.deskRef.add(entry).then(function(docRef){docRef.update({id:`${docRef.id}`})});
+            // return context.getters.deskRef.doc(entry.id).update({ wasLive: false })
         }),
         sendDeskToFeedRef: firestoreAction(async (context, entry) => {
             await context.getters.feedRef.doc(entry.id).set({ ...entry })
+            await context.getters.feedRef.doc(entry.id).update({ wasLive: false })
             return context.getters.deskRef.doc(entry.id).delete()
         }),
         updateContribsCount: firestoreAction(async (context, count) => {
@@ -89,6 +92,7 @@ export default {
         }),
         withdrawLiveVerse: firestoreAction(async (context, entry) => {
             await context.getters.deskRef.doc(entry.id).set({ ...entry })
+            await context.getters.deskRef.doc(entry.id).update({ wasLive: false })
             return context.getters.feedRef.doc(entry.id).delete()
         }),
         removeQueueElementRef: firestoreAction((context, entryId) => {

--- a/client/src/views/Events/Modules/Feed/Info.vue
+++ b/client/src/views/Events/Modules/Feed/Info.vue
@@ -28,7 +28,7 @@
                     <input type="text" class="mb-3 form-input" v-model="newDeskEntry.title" placeholder="Title" />
                     <textarea rows="3" class="mb-3 form-input" v-model="newDeskEntry.content" placeholder="Content" />
                 </template>
-                <List :elements="desk" :searchable="false">
+                <List :elements="desk = testDesk.concat(liveDesk)" :searchable="false">
                     <template v-slot:list="{ elements }">
                         <DeskEntry v-for="element in elements" :key="element.id" :element="element"/>
                     </template>
@@ -57,7 +57,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('contributions', ['desk']),
+        ...mapState('contributions', ['desk', 'liveDesk', 'testDesk']),
         AllowedTypes(){
             return [ContributionTypes.DEFAULT, ContributionTypes.INFORMATION, ContributionTypes.QUOTE, ContributionTypes.BIBLEVERSE];
         },
@@ -75,11 +75,13 @@ export default {
         },
     },
     async mounted(){
-        await this.bindDeskRef();
+        await this.bindDeskRef()
+        await this.bindLiveDeskRef();
     },
     methods: {
         ...mapActions('contributions', ['addToDeskRef']),
         ...mapActions('contributions', ['bindDeskRef']),
+        ...mapActions('contributions', ['bindLiveDeskRef']),
         async addElement(){
             if (this.isCompleted) {
                 this.newDeskEntry.date = Date.now();

--- a/client/src/views/Events/Modules/Feed/Info.vue
+++ b/client/src/views/Events/Modules/Feed/Info.vue
@@ -87,15 +87,10 @@ export default {
         await this.bindLiveDeskRef();
     },
     methods: {
-        ...mapActions('contributions', ['addToDeskRef']),
-        ...mapActions('contributions', ['bindDeskRef']),
-        ...mapActions('contributions', ['bindLiveDeskRef']),
+        ...mapActions('contributions', ['addToDeskRef', 'bindDeskRef', 'bindLiveDeskRef']),
         async addElement(){
             if (this.isCompleted) {
                 this.newDeskEntry.date = Date.now();
-                // if(this.newDeskEntry.verse.verse_to == undefined) {
-                //     this.newDeskEntry.verse.verse_to = this.newDeskEntry.verse.verse_from
-                // }
                 await this.addToDeskRef(this.newDeskEntry).then((result) => {
                     this.$toasted.success(this.$t('queue.element-added'));
                     const newDeskEntry = { type: 1 };

--- a/client/src/views/Events/Modules/Feed/Info.vue
+++ b/client/src/views/Events/Modules/Feed/Info.vue
@@ -93,6 +93,9 @@ export default {
         async addElement(){
             if (this.isCompleted) {
                 this.newDeskEntry.date = Date.now();
+                // if(this.newDeskEntry.verse.verse_to == undefined) {
+                //     this.newDeskEntry.verse.verse_to = this.newDeskEntry.verse.verse_from
+                // }
                 await this.addToDeskRef(this.newDeskEntry).then((result) => {
                     this.$toasted.success(this.$t('queue.element-added'));
                     const newDeskEntry = { type: 1 };

--- a/client/src/views/Events/Modules/Feed/Info.vue
+++ b/client/src/views/Events/Modules/Feed/Info.vue
@@ -28,9 +28,15 @@
                     <input type="text" class="mb-3 form-input" v-model="newDeskEntry.title" placeholder="Title" />
                     <textarea rows="3" class="mb-3 form-input" v-model="newDeskEntry.content" placeholder="Content" />
                 </template>
-                <List :elements="desk = testDesk.concat(liveDesk)" :searchable="false">
+                <List :elements="desk" :searchable="false">
                     <template v-slot:list="{ elements }">
                         <DeskEntry v-for="element in elements" :key="element.id" :element="element"/>
+                    </template>
+                    <template v-slot:newElement></template>
+                </List>
+                <List :elements="liveDesk" :searchable="false">
+                    <template v-slot:list="{ elements }">
+                        <LiveDeskEntry v-for="element in elements" :key="element.id" :element="element"/>
                     </template>
                     <template v-slot:newElement></template>
                 </List>
@@ -44,11 +50,13 @@ import { ContributionTypes, ContributionTypesLabels } from '@/models/contributio
 import { mapState, mapActions } from 'vuex';
 import List from '@/components/List/List.vue'
 import DeskEntry from '@/components/List/Elements/Contribution/Desk.vue'
+import LiveDeskEntry from '@/components/List/Elements/Contribution/LiveDesk.vue'
 import BibleVerse from '@/components/Forms/BibleVerse.vue';
 export default {
     components: {
         List,
         DeskEntry,
+        LiveDeskEntry,
         BibleVerse,
     },
     data: function() {
@@ -57,10 +65,13 @@ export default {
         }
     },
     computed: {
-        ...mapState('contributions', ['desk', 'liveDesk', 'testDesk']),
+        ...mapState('contributions', ['desk', 'liveDesk']),
         AllowedTypes(){
             return [ContributionTypes.DEFAULT, ContributionTypes.INFORMATION, ContributionTypes.QUOTE, ContributionTypes.BIBLEVERSE];
         },
+        // combinedList() {
+        //     return this.desk.concat(this.liveDesk)
+        // },
         ContributionTypes(){
             return ContributionTypes
         },

--- a/client/src/views/Events/Modules/Feed/Info.vue
+++ b/client/src/views/Events/Modules/Feed/Info.vue
@@ -69,9 +69,6 @@ export default {
         AllowedTypes(){
             return [ContributionTypes.DEFAULT, ContributionTypes.INFORMATION, ContributionTypes.QUOTE, ContributionTypes.BIBLEVERSE];
         },
-        // combinedList() {
-        //     return this.desk.concat(this.liveDesk)
-        // },
         ContributionTypes(){
             return ContributionTypes
         },


### PR DESCRIPTION
## Features:
- Added a new list with the live verses below the list with the verses ready to be pushed 
- You can edit the live Verses and when you press save it will get displayed on live screen agin with the new data
- Added 4 buttons to the live edit (+1, +2, ...) that extend the Verse by that amount 
- if you click a button a popup asks you if you realy want to extend that verse by that amount

## Problems:
- there is no protection to extending the verse over the amount of verses actualy existing in the chapter
- when you extend the verse with the button it will show the correct verse on live screen but the prewiev only gets updated in the edit view and not out side the edit view untill you press the save button (this showes the verse again on live screen)

